### PR TITLE
Fix mafft conda environment creation error

### DIFF
--- a/workflow/envs/tools.yaml
+++ b/workflow/envs/tools.yaml
@@ -1,12 +1,13 @@
 channels:
  - conda-forge
  - bioconda
+ - nodefaults
 dependencies:
  - trimal=1.4.1
  - seqkit=0.14.0-0
  - hmmer=3.3.2
  - cd-hit=4.8.1
- - mafft=7.475
+ - mafft>=7.475
  - ffindex=0.98
  - csvkit=1.0.7
  - curl=7.83.1


### PR DESCRIPTION
- Add 'nodefaults' channel to exclude defaults channel conflicts
- Change mafft version from exact pin (=7.475) to flexible (>=7.475)
- Resolves LibMambaUnsatisfiableError with strict repo priority