### PR TITLE
Fix ValueError when parsing gap-only alignment blocks in HMMER output

### DIFF
--- a/workflow/scripts/extract_hmmsearch.py
+++ b/workflow/scripts/extract_hmmsearch.py
@@ -124,9 +124,14 @@ def parse_aln_block(fh):
 
     line = next(fh)
     fields = re.split(" +", line.strip())
-    vals['ali_left']  = int(fields[-3])
+    # Sequence line can have '-' for positions when alignment is all gaps (no sequence aligned)
+    # Gap-only sequences are handled correctly downstream (gaps are skipped in position tracking)
+    # Use ali_left/ali_right = None to indicate missing/invalid values
+    ali_left_str = fields[-3]
+    ali_right_str = fields[-1]
+    vals['ali_left']  = int(ali_left_str) if ali_left_str != '-' else None
     vals['ali_seq']   = fields[-2]
-    vals['ali_right'] = int(fields[-1])
+    vals['ali_right'] = int(ali_right_str) if ali_right_str != '-' else None
     
     line = next(fh)
     fields = re.split(' +', line.strip(), 2)


### PR DESCRIPTION
When HMMER outputs alignment blocks with all gaps (no sequence aligned), it uses '-' for sequence positions instead of numbers. This caused a ValueError when trying to convert '-' to int.

Changes:
- Handle '-' values in ali_left and ali_right by converting to None
- Downstream code correctly handles gaps (they're skipped in position tracking)

Fixes parsing errors like:
  ValueError: invalid literal for int() with base 10: '-'